### PR TITLE
Refactor: be explicit about writing in memory once

### DIFF
--- a/src/main/java/com/eronalves/Cursor.java
+++ b/src/main/java/com/eronalves/Cursor.java
@@ -15,13 +15,12 @@ public class Cursor {
     }
 
     public int nextWrite() {
-        writePos = ++writePos % maxPos;
-        return writePos;
+        return writePos = (writePos + 1) % maxPos;
     }
 
     public int nextRead() {
         int temp = readPos;
-        readPos = ++readPos % maxPos;
+        readPos = (readPos + 1) % maxPos;
         return temp;
     }
 


### PR DESCRIPTION
The pre-increment operator has an implicit `putfield` bytecode generated that is unecessary in this case (as it alreay is thread unsafe).

For comparison, original output for `nextWrite` is:

```
       0: aload_0
       1: aload_0
       2: dup
       3: getfield      #16                 // Field writePos:I
       6: iconst_1
       7: iadd
       8: dup_x1
       9: putfield      #16                 // Field writePos:I
      12: aload_0
      13: getfield      #19                 // Field maxPos:I
      16: irem
      17: putfield      #16                 // Field writePos:I
      20: aload_0
      21: getfield      #16                 // Field writePos:I
      24: ireturn
```

And now:

```
       0: aload_0
       1: aload_0
       2: getfield      #16                 // Field writePos:I
       5: iconst_1
       6: iadd
       7: aload_0
       8: getfield      #19                 // Field maxPos:I
      11: irem
      12: dup_x1
      13: putfield      #16                 // Field writePos:I
      16: ireturn
```